### PR TITLE
Fixing an error in markdown parsing

### DIFF
--- a/docs/pages.html.mdx
+++ b/docs/pages.html.mdx
@@ -225,13 +225,13 @@ JSX eats whitespace, which can be a bit confusing. You might be used to breaking
 
 You would expect it would render like this.
 
-```text
+```
 First line second line.
 ```
 
 But with JSX it would actually render like this.
 
-```text
+```
 First linesecond line.
 ```
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,15 +1,17 @@
 import glob from "glob"
-import { normalize } from "path"
+import { normalize, sep as separator } from "path"
 
 export const importComponent = async (path) => {
   try {
     var component = await import(path)
   } catch (error) {
+    const relativePath = path.replace(`${process.cwd()}${separator}`, "")
+    const file = `\nFile: ${relativePath}`
+
     let description = error.toString()
     let codeFrame = error.codeFrame
 
-    const location = `Location: ${path}`
-    error.stack = [location, description, codeFrame].join("\n")
+    error.stack = [file, description, codeFrame].join("\n")
 
     throw error
   }

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -7,7 +7,9 @@ export const importComponent = async (path) => {
   } catch (error) {
     let description = error.toString()
     let codeFrame = error.codeFrame
-    error.stack = [description, codeFrame].join("\n")
+
+    const location = `Location: ${path}`
+    error.stack = [location, description, codeFrame].join("\n")
 
     throw error
   }


### PR DESCRIPTION
In reference to this bug story: https://github.com/brandonweiss/charge/issues/808

My process

```
git clone https://github.com/brandonweiss/charge.git
cd charge
yarn install
node cli.js [build|serve] docs/ tmp/
```

Receive this error for either `build` or `serve`:
```
Error: Unknown language: `text` is not registered
```

I want to mention that I'm really interested in Charge and hope it becomes bigger. I may be forking to see what I can get into it (generalize for myself and others Charge included) so I'd like to be able to play around with it more.