### PR TITLE
Change ZEIT Now to Vercel

### DIFF
--- a/docs/deployment.html.mdx
+++ b/docs/deployment.html.mdx
@@ -23,9 +23,9 @@ S3 supports clean URLs but not implicitly. You have to transform your filenames 
 
 Netlify supports clean URLs (which they call “Pretty URLs”) and have [docs on how to enable them][netlify-docs].
 
-## ZEIT Now
+## Vercel
 
-[ZEIT Now][zeit] is another great place to host a static site for free. It supports custom domains, HTTPS, and has a CDN built in.
+[Vercel][vercel] is another great place to host a static site for free. It supports custom domains, HTTPS, and has a CDN built in.
 
 ## Heroku
 
@@ -35,5 +35,5 @@ You can definitely deploy a static site to [Heroku][heroku] but I wouldn’t rec
 [discharge]: https://github.com/brandonweiss/discharge
 [netlify]: https://www.netlify.com
 [netlify-docs]: https://www.netlify.com/docs/redirects/#trailing-slash
-[zeit]: https://zeit.co
+[vercel]: https://vercel.com/
 [heroku]: https://www.heroku.com


### PR DESCRIPTION
This PR simply changes the copy from `ZEIT Now` to `Vercel` in the deployment section of the docs. 